### PR TITLE
fix: bump Docker/CI to Python 3.12 and split dev-only deps

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,10 +15,10 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.x'
+        python-version: '3.12'
 
     - name: Install dependencies
-      run: pip install -r requirements.txt
+      run: pip install -r requirements.txt -r requirements-dev.txt
 
     - name: Install ExifTool
       run: sudo apt-get update && sudo apt-get install -y libimage-exiftool-perl

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Pythonの公式イメージをベースにする
-FROM python:3.9-slim
+FROM python:3.12-slim
 
 # 作業ディレクトリを設定
 WORKDIR /app

--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ Docker を使わずにローカルで試す場合の手順です。
    - Python 3.9+ を用意
    - ExifTool のインストール（macOS: `brew install exiftool`、Debian/Ubuntu: `sudo apt-get install -y libimage-exiftool-perl`）
    - ライブラリ: `pip install -r requirements.txt`
+   - テスト/開発用ライブラリ（テスト実行時のみ必要）: `pip install -r requirements-dev.txt`
 
 2. 実行例
    - リネーム（プレビュー）: `python rename_images.py /path/to/photos --recursive --dry-run`

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,2 @@
+Pillow
+pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,1 @@
-Pillow
-pytest
 tqdm


### PR DESCRIPTION
- Bump Dockerfile base image from python:3.9-slim (EOL) to python:3.12-slim
- Pin CI python-version to '3.12' to match the Dockerfile
- Move Pillow and pytest (test-only deps) into requirements-dev.txt,
  leaving requirements.txt with only the runtime dep (tqdm)
- Update CI to install both requirements.txt and requirements-dev.txt
- Document requirements-dev.txt in the README local setup steps

Fixes #28, Fixes #29
